### PR TITLE
Fix: sync widget value after editor send-back (blank/black image on newer ComfyUI frontends)

### DIFF
--- a/js/openpose_editor.js
+++ b/js/openpose_editor.js
@@ -61,8 +61,10 @@ class OpenposeEditorDialog extends ComfyDialog {
                 const textAreaElement = poseWidget.element;
                 const poseString = JSON.stringify(event.data.poses);
                 textAreaElement.value = poseString;
-                // Fix: sincronizar el valor interno del widget y notificar al frontend;
-                // si no, ComfyUI ejecuta con POSE_JSON vacio (imagen negra)
+                // Fix: also sync the widget's internal value and notify the frontend.
+                // Setting only the DOM textarea value does not update widget.value on
+                // newer ComfyUI frontends, so the prompt executes with an empty
+                // POSE_JSON and the node outputs a blank (black) image.
                 poseWidget.value = poseString;
                 textAreaElement.dispatchEvent(new Event("input", { bubbles: true }));
                 if (poseWidget.callback) { poseWidget.callback(poseString); }
@@ -96,12 +98,11 @@ class OpenposeEditorDialog extends ComfyDialog {
         }
 
         const targetNode = ComfyApp.clipspace_return_node;
-        //if (targetNode.inputs?.[0].link || targetNode.inputs?.[targetNode.inputs.length-1].widget){
-            //const textAreaElement = targetNode.widgets[15].element;
-		//	const textAreaElement = targetNode.widgets[14].element;
-        //    this.element.style.display = "flex";
-        //    this.setCanvasJSONString(textAreaElement.value.replace(/'/g, '"'));
-        //} else {
+        if (targetNode.inputs?.[0].link || targetNode.inputs?.[targetNode.inputs.length-1].widget){
+            const textAreaElement = targetNode.widgets[15].element;
+            this.element.style.display = "flex";
+            this.setCanvasJSONString(textAreaElement.value.replace(/'/g, '"'));
+        } else {
             const textAreaElement = targetNode.widgets[14].element;
             this.element.style.display = "flex";
             if (textAreaElement.value === "") {
@@ -117,7 +118,7 @@ class OpenposeEditorDialog extends ComfyDialog {
             } else {
                 this.setCanvasJSONString(textAreaElement.value.replace(/'/g, '"'));
             }
-        //}
+        }
     }
 
     createLayout() {

--- a/js/openpose_editor.js
+++ b/js/openpose_editor.js
@@ -57,8 +57,16 @@ class OpenposeEditorDialog extends ComfyDialog {
             const message = event.data;
             if (message.modalId === 0) {
                 const targetNode = ComfyApp.clipspace_return_node;
-                const textAreaElement = targetNode.widgets[14].element;
-                textAreaElement.value = JSON.stringify(event.data.poses);
+                const poseWidget = targetNode.widgets[14];
+                const textAreaElement = poseWidget.element;
+                const poseString = JSON.stringify(event.data.poses);
+                textAreaElement.value = poseString;
+                // Fix: sincronizar el valor interno del widget y notificar al frontend;
+                // si no, ComfyUI ejecuta con POSE_JSON vacio (imagen negra)
+                poseWidget.value = poseString;
+                textAreaElement.dispatchEvent(new Event("input", { bubbles: true }));
+                if (poseWidget.callback) { poseWidget.callback(poseString); }
+                targetNode.setDirtyCanvas(true, true);
 		ComfyApp.onClipspaceEditorClosed();
                 this.close();
             }
@@ -88,11 +96,12 @@ class OpenposeEditorDialog extends ComfyDialog {
         }
 
         const targetNode = ComfyApp.clipspace_return_node;
-        if (targetNode.inputs?.[0].link || targetNode.inputs?.[targetNode.inputs.length-1].widget){
-            const textAreaElement = targetNode.widgets[15].element;
-            this.element.style.display = "flex";
-            this.setCanvasJSONString(textAreaElement.value.replace(/'/g, '"'));
-        } else {
+        //if (targetNode.inputs?.[0].link || targetNode.inputs?.[targetNode.inputs.length-1].widget){
+            //const textAreaElement = targetNode.widgets[15].element;
+		//	const textAreaElement = targetNode.widgets[14].element;
+        //    this.element.style.display = "flex";
+        //    this.setCanvasJSONString(textAreaElement.value.replace(/'/g, '"'));
+        //} else {
             const textAreaElement = targetNode.widgets[14].element;
             this.element.style.display = "flex";
             if (textAreaElement.value === "") {
@@ -108,7 +117,7 @@ class OpenposeEditorDialog extends ComfyDialog {
             } else {
                 this.setCanvasJSONString(textAreaElement.value.replace(/'/g, '"'));
             }
-        }
+        //}
     }
 
     createLayout() {


### PR DESCRIPTION
## Problem

On recent ComfyUI frontends, after editing a pose and sending it back from the Openpose Editor, the node renders a blank (black) image even though the JSON is visible in the `POSE_JSON` textarea.

## Cause

In `js/openpose_editor.js`, the send-back handler only writes to the DOM element:

```js
textAreaElement.value = JSON.stringify(event.data.poses);
```

Setting the DOM textarea value programmatically does not fire an `input` event, so `widget.value` is never updated. When the prompt is executed, the backend receives an empty `POSE_JSON`, falls through to the "output blank images" branch in `openpose_editor_nodes.py`, and returns a black 512x768 image.

## Steps to reproduce

1. Add an `Openpose Editor Node` connected to a `Preview Image` node.
2. Right click -> `Open in Openpose Editor`, add/edit a pose, send back. The JSON appears in the textarea.
3. Queue the prompt without touching the textarea.
4. Result: black image. Workaround without this fix: cut and re-paste the JSON inside the textarea (which fires `input`), then queue again — the pose renders correctly.

## Fix

After writing to the DOM element, also sync the widget's internal value and notify the frontend:

```js
poseWidget.value = poseString;
textAreaElement.dispatchEvent(new Event("input", { bubbles: true }));
if (poseWidget.callback) { poseWidget.callback(poseString); }
targetNode.setDirtyCanvas(true, true);
```

This covers both older and newer frontend versions (whichever sync path the frontend uses, at least one applies). Tested on ComfyUI Desktop (Windows) — after send-back, queueing directly now renders the pose correctly.

Fixes #52
Fixes #51
Partially addresses #46 (the "send pose to controlnet does nothing" part)
