### PR TITLE
Fix: look widgets up by name instead of hardcoded indices in show() (editor crash on open)

### DIFF
--- a/js/openpose_editor.js
+++ b/js/openpose_editor.js
@@ -88,15 +88,22 @@ class OpenposeEditorDialog extends ComfyDialog {
         }
 
         const targetNode = ComfyApp.clipspace_return_node;
-        if (targetNode.inputs?.[0].link || targetNode.inputs?.[targetNode.inputs.length-1].widget){
-            const textAreaElement = targetNode.widgets[15].element;
+        // Fix #49/#45: look widgets up by name instead of hardcoded indices.
+        // Depending on the frontend version, POSE_KEYPOINT may be a socket-only
+        // input with no widget, so widgets[15] can be undefined and reading
+        // .element crashes the editor before it opens.
+        const jsonWidget = targetNode.widgets.find(w => w.name === "POSE_JSON");
+        const keypointWidget = targetNode.widgets.find(w => w.name === "POSE_KEYPOINT");
+        const hasKeypointInput = targetNode.inputs?.[0].link || targetNode.inputs?.[targetNode.inputs.length-1].widget;
+        if (hasKeypointInput && keypointWidget?.element){
+            const textAreaElement = keypointWidget.element;
             this.element.style.display = "flex";
             this.setCanvasJSONString(textAreaElement.value.replace(/'/g, '"'));
         } else {
-            const textAreaElement = targetNode.widgets[14].element;
+            const textAreaElement = jsonWidget.element;
             this.element.style.display = "flex";
             if (textAreaElement.value === "") {
-                let resolution_x = targetNode.widgets[3].value;
+                let resolution_x = targetNode.widgets.find(w => w.name === "resolution_x")?.value ?? -1;
                 let resolution_y = Math.floor(768*(resolution_x*1.0/512));
                 if (resolution_x < 64){
                     resolution_x = 512;


### PR DESCRIPTION
## Problem

On some ComfyUI frontend versions, right-clicking -> "Open in Openpose Editor" crashes before the editor opens:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'element')
    at OpenposeEditorDialog.show (openpose_editor.js:92)
```

## Cause

`show()` accesses widgets by hardcoded index (`widgets[15]`, `widgets[14]`, `widgets[3]`). Depending on the frontend version, `POSE_KEYPOINT` is a socket-only input with no widget, so `widgets[15]` is `undefined` and reading `.element` throws.

## Fix

Look the widgets up by name (`POSE_JSON`, `POSE_KEYPOINT`, `resolution_x`) and guard the `POSE_KEYPOINT` branch with `keypointWidget?.element`, falling back to the `POSE_JSON` widget when it does not exist. This makes the editor robust to widget-order/layout differences across frontend versions.

Fixes #49
Possibly fixes #45 (same symptom: error when trying to open the editor)